### PR TITLE
Remove Deploy Step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,3 @@ cache:
 script:
   - ./gradlew build --build-cache -PwarningsAsErrors=true
   - ./gradlew shadowJar
-
-deploy:
-  provider: releases
-  api_key: "$GITHUB_TOKEN"
-  file: "build/libs/kafka-connect-dynamodb-${TRAVIS_TAG}.jar"
-  skip_cleanup: true
-  on:
-    tags: true


### PR DESCRIPTION
## What

Removes the `deploy` step.

## Why

The `deploy` step uses the GitHub Releases provider. We should create releases manually, and only use such release automation on private repos. Discussed with Emilio.

---

Pull request opened by github-pullrequestcreator.